### PR TITLE
Fixing find sintax to find package or cabal files for project.digest …

### DIFF
--- a/src/scripts/digest.sh
+++ b/src/scripts/digest.sh
@@ -1,7 +1,7 @@
 # TODO: once committing the cabal file catches on, we can just
 # assume it exists and md5sum *.cabal here.
 find . -maxdepth 1 -type f \
-  -name package.yaml -name '*.cabal' \
+  -name package.yaml -o -name '*.cabal' \
   -exec md5sum {} + > project.digest
 
 git ls-files | xargs md5sum > source.digest


### PR DESCRIPTION
This PR fixes an issue with finding  `package.yaml `or the   `'*.cabal` file when creating the `project.digest` hash. 